### PR TITLE
修复纹理重复翻转

### DIFF
--- a/docs/01 Getting started/07 Transformations.md
+++ b/docs/01 Getting started/07 Transformations.md
@@ -445,7 +445,7 @@ uniform mat4 transform;
 void main()
 {
     gl_Position = transform * vec4(aPos, 1.0f);
-    TexCoord = vec2(aTexCoord.x, 1.0 - aTexCoord.y);
+    TexCoord = vec2(aTexCoord.x, aTexCoord.y);
 }
 ```
 


### PR DESCRIPTION
您好，

我在学习《变换》(Transformations) 章节时，发现 C++ 示例代码与顶点着色器代码之间存在一个逻辑上的矛盾，导致纹理被双重翻转。

### 问题所在 (The Issue)

*   **文件**: `01 Getting started/07 Transformations.md`
*   **C++ 代码**: 使用了 `stbi_set_flip_vertically_on_load(true);`，在加载时已经对纹理进行了Y轴翻转。
*   **顶点着色器 (GLSL) 代码**: 依然保留了 `TexCoord = vec2(aTexCoord.x, 1.0 - aTexCoord.y);`，对纹理坐标进行了第二次Y轴翻转。

这种双重翻转会相互抵消，导致最终渲染出来的纹理效果是错误的（上下颠倒），与教程的预期不符。

### 所做的修改 (The Fix)

本次提交移除了顶点着色器中多余的Y轴翻转逻辑。

我将顶点着色器中的代码：

```glsl
TexCoord = vec2(aTexCoord.x, 1.0 - aTexCoord.y);
```

修改为：

```glsl
TexCoord = vec2(aTexCoord.x, aTexCoord.y);
```

### 验证 (Verification)

此修改使得着色器逻辑与C++代码中的 stbi 设置保持一致。我也查阅了 LearnOpenGL 英文原版网站，其采用的正是这种修正后的方案。

这样修改后，纹理能够被正确地渲染，符合教程预期。

感谢你们为社区提供的优秀翻译和维护！